### PR TITLE
Add commonSettings to the root project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 lazy val root = (project in file("."))
   .aggregate(itemApi, itemImpl, biddingApi, biddingImpl, userApi, userImpl, webGateway)
+  .settings(commonSettings: _*)
 
 organization in ThisBuild := "com.example"
 


### PR DESCRIPTION
This allows IntelliJ IDEA to pick up the javac options and apply them to builds in the IDE.