### PR TITLE
Fix the Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
     - $HOME/.ivy2/cache
 before_cache:
   # Ensure changes to the cache aren't persisted
-  - rm -rf $HOME/.ivy2/cache/sample.helloworld/hello*
+  - rm -rf $HOME/.ivy2/cache/com.example
   # Delete all ivydata files since ivy touches them on each build
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" | xargs rm
 notifications:

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val root = (project in file("."))
 organization in ThisBuild := "com.example"
 
 // the Scala version that will be used for cross-compiled libraries
-scalaVersion in ThisBuild := "2.11.7"
+scalaVersion in ThisBuild := "2.11.8"
 
 lazy val security = (project in file("security"))
   .settings(commonSettings: _*)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@
 //
 
 // The Lagom plugin
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.2.0-SNAPSHOT")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.2.0-RC2")
 // Needed for importing the project into Eclipse
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "3.0.0")
 // The ConductR plugin


### PR DESCRIPTION
- Use Lagom 1.2.0-RC2 instead of depending on a SNAPSHOT
- Update the organization for the ivy cache
- Change `scalaVersion` to `2.11.8` to silence warnings

This let's us set up a build for this project. See https://travis-ci.org/TimMoore/online-auction-java for example.

I don't have the permission I need to actually create the build for this project in Travis, so I think you'll need to do it @jroper.