### PR TITLE
Add a name to the root project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 lazy val root = (project in file("."))
+  .settings(name := "online-auction-java")
   .aggregate(itemApi, itemImpl, biddingApi, biddingImpl, userApi, userImpl, webGateway)
   .settings(commonSettings: _*)
 


### PR DESCRIPTION
This improves the IntelliJ import behavior.