### PR TITLE
Make the circuit breakers more tolerant of slow-to-start services

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 #Activator-generated Properties
 #Sat Sep 03 14:50:21 AEST 2016
 template.uuid=79abc40b-9334-4daa-972c-6bfc4c9c90e4
-sbt.version=0.13.11
+sbt.version=0.13.13

--- a/web-gateway/conf/application.conf
+++ b/web-gateway/conf/application.conf
@@ -1,7 +1,3 @@
-
-
-lagom.circuit-breaker.default.call-timeout = 5s
-
 play.crypto.secret = "somesecret"
 
 lagom.play {
@@ -11,13 +7,4 @@ lagom.play {
       path-regex = "(?!/api/).*"
     }
   ]
-}
-
-lagom.circuit-breaker {
-  default {
-    enabled = on
-    max-failures = 10
-    call-timeout = 10s
-    reset-timeout = 15s
-  }
 }

--- a/web-gateway/conf/application.conf
+++ b/web-gateway/conf/application.conf
@@ -12,3 +12,12 @@ lagom.play {
     }
   ]
 }
+
+lagom.circuit-breaker {
+  default {
+    enabled = on
+    max-failures = 10
+    call-timeout = 10s
+    reset-timeout = 15s
+  }
+}


### PR DESCRIPTION
On my machine the downstream services take a few seconds to respond to the very first requests which trips the default config for the circuit breakers.  This seems to work around the problem so now the frontend responds as soon as runAll finishes.

In debugging this, one suggestion was that sbt could have an effect, so I updated it to avoid any confusion.