### PR TITLE
Update .travis.yml to workaround build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
   - sudo service elasticsearch restart
 before_script:
   - sleep 20
+  - sudo chmod +x /usr/local/bin/sbt # see https://github.com/travis-ci/travis-ci/issues/7703
 script:
   - sbt -DenableElasticsearch=true test
 cache:


### PR DESCRIPTION
Travis recently upgraded the default images for the build machines.

`online-auction-java`  uses `sudo: required` which is run a different type of machine that other lagom jobs. There's a [bug](https://github.com/travis-ci/travis-ci/issues/7703) on that new image. This PR introduces the workaround suggested in the linked bug.