### PR TITLE
Removes unused dependency from searchImpl

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,6 @@ lazy val searchImpl = (project in file("search-impl"))
   .settings(
     version := "1.0-SNAPSHOT",
     libraryDependencies ++= Seq(
-      lagomJavadslPersistenceCassandra,
       lagomJavadslTestKit,
       lagomJavadslKafkaClient,
       lombok


### PR DESCRIPTION
This dependency from serach-impl to lagom-cassandra-persistence passed under the radar for few months. I've seen it cause failures when running the app in conductr with lagom 1.4.x