### PR TITLE
Fixes startup issue caused by removal of play.api.Configuration

### DIFF
--- a/web-gateway/app/ConfigProvider.java
+++ b/web-gateway/app/ConfigProvider.java
@@ -1,0 +1,18 @@
+import com.typesafe.config.Config;
+import play.Configuration;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+/**
+ *
+ */
+@Singleton
+public class ConfigProvider implements Provider<Config> {
+    @Inject private Configuration configuration;
+    @Override
+    public Config get() {
+        return configuration.underlying();
+    }
+}

--- a/web-gateway/app/Module.java
+++ b/web-gateway/app/Module.java
@@ -7,11 +7,14 @@ import com.lightbend.lagom.javadsl.api.ServiceAcl;
 import com.lightbend.lagom.javadsl.api.ServiceInfo;
 import com.google.inject.AbstractModule;
 import com.lightbend.lagom.javadsl.client.ServiceClientGuiceSupport;
+import com.typesafe.config.Config;
 
 public class Module extends AbstractModule implements ServiceClientGuiceSupport {
     @Override
     protected void configure() {
         bindServiceInfo(ServiceInfo.of("web-gateway-module", ServiceAcl.path("(?!/api/).*")));
+        // TODO: remove this and the ConfigProvider when upgrading to Lagom 1.4.0
+        binder().bind(Config.class).toProvider(ConfigProvider.class);
         bindClient(UserService.class);
         bindClient(ItemService.class);
         bindClient(BiddingService.class);


### PR DESCRIPTION
When adding changes in `master` in preparation for bump to Lagom 1.4.0 I introduced a runtime error deeming the `web-gateway` unusable.