### PR TITLE
Opt in to the Trusty build environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: scala
+dist: trusty
 sudo: required
 jdk:
   - oraclejdk8


### PR DESCRIPTION
This will soon be the default, but opting in lets us test it in advance of the change.

For more information, see these pages:
- https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming
- https://docs.travis-ci.com/user/trusty-ci-environment/