### PR TITLE
Fixes login for happy path

### DIFF
--- a/item-impl/src/test/java/com/example/auction/item/impl/ItemServiceImplIntegrationTest.java
+++ b/item-impl/src/test/java/com/example/auction/item/impl/ItemServiceImplIntegrationTest.java
@@ -41,7 +41,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class ItemServiceImplIntegrationTest {
 
-    private final static Setup setup = defaultSetup().withCassandra(true)
+    private final static Setup setup = defaultSetup().withCassandra()
             .configureBuilder(b ->
                     // by default, cassandra-query-journal delays propagation of events by 10sec. In test we're using
                     // a 1 node cluster so this delay is not necessary.

--- a/item-impl/src/test/java/com/example/auction/item/impl/ItemServiceImplIntegrationTest.java
+++ b/item-impl/src/test/java/com/example/auction/item/impl/ItemServiceImplIntegrationTest.java
@@ -41,7 +41,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class ItemServiceImplIntegrationTest {
 
-    private final static Setup setup = defaultSetup().withCassandra()
+    private final static Setup setup = defaultSetup().withCassandra(true)
             .configureBuilder(b ->
                     // by default, cassandra-query-journal delays propagation of events by 10sec. In test we're using
                     // a 1 node cluster so this delay is not necessary.

--- a/user-impl/src/main/java/com/example/auction/user/impl/PUserEntity.java
+++ b/user-impl/src/main/java/com/example/auction/user/impl/PUserEntity.java
@@ -45,7 +45,6 @@ public class PUserEntity extends PersistentEntity<PUserCommand, PUserEvent, Opti
         );
 
         b.setCommandHandler(CreatePUser.class, (create, ctx) -> {
-
             PUser user = new PUser(UUID.fromString(entityId()),  create.getName(), create.getEmail(), create.getPasswordHash());
             return ctx.thenPersist(new PUserCreated(user), (e) -> ctx.reply(Optional.ofNullable(user)));
         });

--- a/user-impl/src/test/java/com/example/auction/user/impl/UserServiceImplTest.java
+++ b/user-impl/src/test/java/com/example/auction/user/impl/UserServiceImplTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.fail;
 public class UserServiceImplTest {
 
 
-    private final static ServiceTest.Setup setup = defaultSetup().withCassandra(true)
+    private final static ServiceTest.Setup setup = defaultSetup().withCassandra()
         .configureBuilder(b ->
             // by default, cassandra-query-journal delays propagation of events by 10sec. In test we're using
             // a 1 node cluster so this delay is not necessary.

--- a/user-impl/src/test/java/com/example/auction/user/impl/UserServiceImplTest.java
+++ b/user-impl/src/test/java/com/example/auction/user/impl/UserServiceImplTest.java
@@ -1,40 +1,91 @@
 package com.example.auction.user.impl;
 
 import com.example.auction.user.api.User;
+import com.example.auction.user.api.UserLogin;
 import com.example.auction.user.api.UserRegistration;
 import com.example.auction.user.api.UserService;
 import com.example.testkit.Await;
+import com.lightbend.lagom.javadsl.api.transport.NotFound;
+import com.lightbend.lagom.javadsl.testkit.ServiceTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
 
 import static com.lightbend.lagom.javadsl.testkit.ServiceTest.defaultSetup;
 import static com.lightbend.lagom.javadsl.testkit.ServiceTest.withServer;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class UserServiceImplTest {
 
-    private final String name = "admin";
-    private final String email = "admin@gmail.com";
-    private final String password = "admin";
+
+    private final static ServiceTest.Setup setup = defaultSetup().withCassandra(true)
+        .configureBuilder(b ->
+            // by default, cassandra-query-journal delays propagation of events by 10sec. In test we're using
+            // a 1 node cluster so this delay is not necessary.
+            b.configure("cassandra-query-journal.eventual-consistency-delay", "0")
+        );
+
+    @BeforeClass
+    public static void beforeAll() {
+        server = ServiceTest.startServer(setup);
+        userService = server.client(UserService.class);
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        server.stop();
+    }
+
+    private static ServiceTest.TestServer server;
+
     private static UserService userService;
 
 
     @Test
     public void shouldBeAbleToCreateUsers() throws Exception {
-        withServer(defaultSetup().withCassandra(), server -> {
-            userService = server.client(UserService.class);
-            UserRegistration userRegistration = new UserRegistration(name, email, password);
-            User createdUser = createNewUser(userRegistration);
-            assertEquals(name, createdUser.getName());
-            assertEquals(email, createdUser.getEmail());
+        String name = "admin";
+        String email = "admin@gmail.com";
+        String password = "admin";
+        userService = server.client(UserService.class);
+        UserRegistration userRegistration = new UserRegistration(name, email, password);
+        User createdUser = createNewUser(userRegistration);
+        assertEquals(name, createdUser.getName());
+        assertEquals(email, createdUser.getEmail());
+    }
 
-        });
+    @Test
+    public void shouldBeAllowLoggingInWithValidCredentials() throws Exception {
+        String name = "admin2";
+        String email = "admin2@gmail.com";
+        String password = "admin2";
+        userService = server.client(UserService.class);
+        UserRegistration userRegistration = new UserRegistration(name, email, password);
+        User createdUser = createNewUser(userRegistration);
+
+        Await.result(userService.login().invoke(new UserLogin(email, password)));
+        // no assertion required.
+    }
+
+    // TODO: replace with Forbidden.class
+    @Test(expected = NotFound.class)
+    public void shouldDenyLoggingInWithInalidCredentials() throws Throwable {
+        try {
+            Await.result(userService.login().invoke(
+                new UserLogin("invalid-email@domain.com", "123456"))
+            );
+        } catch (RuntimeException e) {
+            throw e.getCause();
+        }
     }
 
     private User createNewUser(UserRegistration userRegistration) {
         return Await.result(
-                userService
-                        .createUser()
-                        .invoke(userRegistration)
+            userService
+                .createUser()
+                .invoke(userRegistration)
         );
 
     }


### PR DESCRIPTION
This PR replaces the way the userId is computed by a derived alg that canonicalizes the e-mail and uses it's `byte[]` to build the UUID. It's not great but it works for the time being.

The canonicalization uses a `toLowerCase` so that username is not case sensitive on login. Password still is case sensitive.

This PR removes the offending Cassandra query that serached by `email = ?`.


This PR doesn't fix the cosmetic issues (the login page should be displayed instead of a default play screen)  or data leaks in case of failed login attempts (`wrong e-mail` uses a different error message than `valid email but wrong password`).

Lots of code formatting.