### PR TITLE
Disables java serialization

### DIFF
--- a/bidding-impl/src/main/resources/application.conf
+++ b/bidding-impl/src/main/resources/application.conf
@@ -19,3 +19,5 @@ akka.actor.serialization-bindings {
   "akka.actor.Address"        = akka-misc
   "akka.remote.UniqueAddress" = akka-misc
 }
+
+akka.actor.allow-java-serialization = off

--- a/item-impl/src/main/resources/application.conf
+++ b/item-impl/src/main/resources/application.conf
@@ -23,3 +23,5 @@ akka.actor.serialization-bindings {
   "akka.actor.Address"        = akka-misc
   "akka.remote.UniqueAddress" = akka-misc
 }
+
+akka.actor.allow-java-serialization = off

--- a/transaction-impl/src/main/resources/application.conf
+++ b/transaction-impl/src/main/resources/application.conf
@@ -18,3 +18,5 @@ akka.actor.serialization-bindings {
   "akka.actor.Address"        = akka-misc
   "akka.remote.UniqueAddress" = akka-misc
 }
+
+akka.actor.allow-java-serialization = off

--- a/user-impl/src/main/resources/application.conf
+++ b/user-impl/src/main/resources/application.conf
@@ -11,3 +11,5 @@ akka.actor.serialization-bindings {
   "akka.actor.Address"        = akka-misc
   "akka.remote.UniqueAddress" = akka-misc
 }
+
+akka.actor.allow-java-serialization = off


### PR DESCRIPTION
Fixes #171 

Changes provided in this PR don't cause any significant change. To see the real impact you can enable the now-`@Ignore`'d test `ItemEntityTest#shouldFailWhenUpdatingAnItemThatDoesntExist`.

Once `ItemEntityTest#shouldFailWhenUpdatingAnItemThatDoesntExist` is enabled, if you run the test without this PR you get this failure:

```
[WARN] [SECURITY][03/23/2018 11:38:47.847] [pool-1-thread-1] [akka.serialization.Serialization(akka://default)] Using the default Java serializer for class [com.lightbend.lagom.javadsl.api.transport.NotFound] which is not recommended because of performance implications. Use another serializer or disable this warning using the setting 'akka.actor.warn-about-java-serializer-usage'
Object [com.lightbend.lagom.javadsl.api.transport.NotFound: 508cf452-a8b3-4ff3-8495-e94174a91fb9 (TransportErrorCode{http=404, webSocket=1008, description='Policy Violation'})] does not equal [com.lightbend.lagom.javadsl.api.transport.NotFound: 508cf452-a8b3-4ff3-8495-e94174a91fb9 (TransportErrorCode{http=404, webSocket=1008, description='Policy Violation'})] after serialization/deserialization
```

Once `ItemEntityTest#shouldFailWhenUpdatingAnItemThatDoesntExist` is enabled, if you run the test with the changes in _this_ PR you get this other failure:

```
[WARN] [SECURITY][03/23/2018 11:33:44.596] [pool-1-thread-1] [akka.serialization.Serialization(akka://default)] Using the default Java serializer for class [com.lightbend.lagom.javadsl.api.transport.NotFound] which is not recommended because of performance implications. Use another serializer or disable this warning using the setting 'akka.actor.warn-about-java-serializer-usage'
[WARN] [SECURITY][03/23/2018 11:33:44.598] [pool-1-thread-1] [DisabledJavaSerializer(akka://default)] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class com.lightbend.lagom.javadsl.api.transport.NotFound]
class com.lightbend.lagom.javadsl.api.transport.NotFound is not serializable, Attempted to serialize message using Java serialization while `akka.actor.allow-java-serialization` was disabled. Check WARNING logs for more details.
```

In one case, the test fails because `NotFound` doesn't include `equals` and `hashcode` (`Object [...] does not equal [...] after serialization/deserialization` while in the other case test fails because there's no serializer for `NotFound`.



