### PR TITLE
Remove tiny redundancy.

### DIFF
--- a/search-impl/src/main/java/com/example/elasticsearch/Elasticsearch.java
+++ b/search-impl/src/main/java/com/example/elasticsearch/Elasticsearch.java
@@ -24,7 +24,7 @@ public interface Elasticsearch extends  Service {
     ServiceCall<QueryRoot, SearchResult> search(String index);
 
     @Override
-    default public Descriptor descriptor() {
+    default Descriptor descriptor() {
         return named("elastic-search")
                 .withCalls(
                         Service.restCall(Method.GET, "/:index/items/_search", this::search),


### PR DESCRIPTION
'public' is not needed in the interface.